### PR TITLE
Implement POST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ tests-once: install-dev
 	$(VENV)/bin/nosetests -s --with-mocha-reporter --cover-min-percentage=100 --with-coverage --cover-package=syncto
 
 tests:
+	@rm -fr .coverage
 	tox
 
 clean:

--- a/syncto/headers.py
+++ b/syncto/headers.py
@@ -10,5 +10,5 @@ def convert_headers(sync_raw_response, syncto_response):
     if 'X-Weave-Next-Offset' in response_headers:
         headers['Next-Page'] = str(response_headers['X-Weave-Next-Offset'])
 
-    if 'X-Weave-Records':
+    if 'X-Weave-Records' in response_headers:
         headers['Total-Records'] = str(response_headers['X-Weave-Records'])

--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -178,6 +178,7 @@ class RecordTest(BaseWebTest, unittest.TestCase):
             "id": "Y_-5-LEeQBuh60IT0MyWEQ",
             "modified": 14377478425.69
         }
+        self.sync_client.return_value.put_record.return_value = 14377478425.69
 
         self.addCleanup(p.stop)
 
@@ -216,3 +217,16 @@ class RecordTest(BaseWebTest, unittest.TestCase):
         self.sync_client.return_value.delete_record.side_effect = HTTPError(
             response=response)
         self.app.delete(RECORD_URL, headers=self.headers, status=404)
+
+    def test_can_put_valid_record(self):
+        record = {
+            "data": {
+                "payload": "abcd"
+            }
+        }
+        self.app.put_json(RECORD_URL, record, headers=self.headers, status=200)
+
+    def test_put_record_reject_invalid_record(self):
+        invalid = {"payload": "foobar"}
+        self.app.put_json(RECORD_URL, invalid, headers=self.headers,
+                          status=400)

--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -162,6 +162,14 @@ class CollectionTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
             resp, 400, ERRORS.INVALID_PARAMETERS, "Invalid parameters",
             "Invalid id in ids list.")
 
+    def test_collection_correctly_convert_sync_headers(self):
+        resp = self.app.get(COLLECTION_URL,
+                            headers=self.headers, status=200)
+        self.assertIn('Total-Records', resp.headers)
+        self.assertIn('Next-Page', resp.headers)
+        self.assertEquals(resp.headers['Total-Records'], '1')
+        self.assertEquals(resp.headers['Next-Page'], '12345')
+
 
 class RecordTest(BaseWebTest, unittest.TestCase):
 

--- a/syncto/views/record.py
+++ b/syncto/views/record.py
@@ -1,11 +1,19 @@
-from pyramid.security import NO_PERMISSION_REQUIRED
+import re
 
-from cliquet import Service
+from cliquet import Service, schema
+from pyramid.security import NO_PERMISSION_REQUIRED
 
 from syncto.authentication import build_sync_client
 from syncto.headers import convert_headers
 from syncto.utils import base64_to_uuid4, uuid4_to_base64
 
+
+SYNC_ID_FORMAT = re.compile(r'^[a-zA-Z0-9_-]{12}$')  # 9 bytes URL safe base64
+
+
+class RecordSchema(schema.ResourceSchema):
+    class Options():
+        preserve_unknown = True
 
 record = Service(name='record',
                  description='Firefox Sync Collection Record service',
@@ -25,6 +33,30 @@ def record_get(request):
 
     record['last_modified'] = int(record.pop('modified') * 1000)
     record['id'] = base64_to_uuid4(record.pop('id'))
+
+    # Configure headers
+    convert_headers(sync_client.raw_resp, request.response)
+
+    return {'data': record}
+
+
+@record.put(permission=NO_PERMISSION_REQUIRED, schema=RecordSchema)
+def record_put(request):
+    collection_name = request.matchdict['collection_name']
+    record_id = request.matchdict['record_id']
+    sync_id = uuid4_to_base64(record_id)
+
+    if_unmodified_since = request.headers.get('If-Match')
+
+    record = request.validated['data']
+    record['id'] = sync_id
+
+    sync_client = build_sync_client(request)
+    last_modified = sync_client.put_record(collection_name, record,
+                                           if_unmodified_since)
+
+    record['last_modified'] = int(last_modified * 1000)
+    record['id'] = record_id
 
     # Configure headers
     convert_headers(sync_client.raw_resp, request.response)


### PR DESCRIPTION
In order to also upload (not only download) history from a Firefox OS device, we will need the [POST verb](http://kinto.readthedocs.org/en/latest/api/records.html#replacing-a-record).
