### PR TITLE
CORS headers missing on 404 responses

### DIFF
--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -50,6 +50,15 @@ class FunctionalTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
             resp, 401, ERRORS.MISSING_AUTH_TOKEN, "Unauthorized",
             "Provide the tokenserver %s header." % CLIENT_STATE_HEADER)
 
+    def test_404_endpoint_returns_cors_headers(self):
+        headers = self.headers.copy()
+        headers['Origin'] = 'notmyidea.org'
+        response = self.app.get('/unknown',
+                                headers=headers,
+                                status=404)
+        self.assertEqual(response.headers['Access-Control-Allow-Origin'],
+                         'notmyidea.org')
+
 
 class CollectionTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
 


### PR DESCRIPTION
When you request a path that results in a 404, that response does not have CORS headers on it.
