### PR TITLE
Translate Kinto timestamps to Sync-server timestamps and back

### DIFF
--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -139,7 +139,16 @@ class CollectionTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
                              '_sort': 'newest'},
                      headers=self.headers, status=200)
         self.sync_client.return_value.get_records.assert_called_with(
-            "tabs", full=True, newer='14377478425700', sort='newest')
+            "tabs", full=True, newer='14377478425.70', sort='newest')
+
+    def test_collection_raises_if_since_parameter_is_not_a_number(self):
+        resp = self.app.get(COLLECTION_URL,
+                            params={'_since': 'not-a-number'},
+                            headers=self.headers, status=400)
+
+        self.assertFormattedError(
+            resp, 400, ERRORS.INVALID_PARAMETERS, "Invalid parameters",
+            "_since should be a number.")
 
     def test_collection_handle_limit_and_token_parameters(self):
         self.app.get(COLLECTION_URL,

--- a/syncto/views/collection.py
+++ b/syncto/views/collection.py
@@ -23,7 +23,14 @@ def collection_get(request):
 
     params = {}
     if '_since' in request.GET:
-        params['newer'] = request.GET['_since']
+        try:
+            params['newer'] = '%.2f' % (int(request.GET['_since']) / 1000.0)
+        except ValueError:
+            error_msg = ("_since should be a number.")
+            raise_invalid(request,
+                          location="querystring",
+                          name="_since",
+                          description=error_msg)
 
     if '_limit' in request.GET:
         params['limit'] = request.GET['_limit']


### PR DESCRIPTION
Kinto.js uses millisecond timestamps in its [`?_since=`](https://github.com/Kinto/kinto.js/blob/master/src/api.js#L135) query parameter, which Syncto then [translates to a `newer` param](https://github.com/mozilla-services/syncto/blob/master/syncto/views/collection.py#L26) to be passed to SyncClient, which [puts it into the params](https://github.com/mozilla-services/syncclient/blob/master/syncclient/client.py#L171) to be sent with [the http request](https://github.com/mozilla-services/syncclient/blob/master/syncclient/client.py#L180) to the SyncServer. So millisecond timestamps are specified in the `newer` parameter there.

The problem is that server-syncstorage expects the `newer` parameter [to be a float value](https://github.com/mozilla-services/server-syncstorage/blob/d961d1012e2c48921180934c369b136b83916a7d/syncstorage/views/validators.py#L84).

This means we're sending timestamps that lie some 45,000 years into the future. :)
