### PR TITLE
Avoid link with cert warning

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Run locally
 ===========
 
-*Sycnto* is based on top of the `cliquet <https://cliquet.rtfd.org>`_ project, and
+*Sycnto* is based on top of the `cliquet <http://cliquet.rtfd.org>`_ project, and
 as such, please refer to cliquet's documentation for more details.
 
 


### PR DESCRIPTION
There is a certificate warning on https://cliquet.rtfd.org, maybe better link to http://cliquet.rtfd.org instead?
