### PR TITLE
Mention ".venv/bin/pip install -Ue ." in "Run locally" instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DEV_STAMP = $(VENV)/.dev_env_installed.stamp
 INSTALL_STAMP = $(VENV)/.install.stamp
 
 .IGNORE: clean
-.PHONY: all install install-dev virtualenv tests clean maintainer-clean docs
+.PHONY: all install install-dev virtualenv tests clean distclean maintainer-clean docs
 
 OBJECTS = .venv .coverage
 
@@ -44,9 +44,11 @@ clean:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -type d -exec rm -fr {} \;
 
-maintainer-clean: clean
-	rm -fr .venv/
-	rm -fr .tox/
+distclean: clean
+	rm -fr *.egg *.egg-info/
+
+maintainer-clean: distclean
+	rm -fr .venv/ .tox/ dist/ build/
 
 # loadtest-check: install
 # 	$(VENV)/bin/cliquet --ini loadtests/server.ini migrate > syncto.log &&\

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DEV_STAMP = $(VENV)/.dev_env_installed.stamp
 INSTALL_STAMP = $(VENV)/.install.stamp
 
 .IGNORE: clean
-.PHONY: all install virtualenv tests
+.PHONY: all install install-dev virtualenv tests clean maintainer-clean docs
 
 OBJECTS = .venv .coverage
 
@@ -43,6 +43,10 @@ tests:
 clean:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -type d -exec rm -fr {} \;
+
+maintainer-clean: clean
+	rm -fr .venv/
+	rm -fr .tox/
 
 # loadtest-check: install
 # 	$(VENV)/bin/cliquet --ini loadtests/server.ini migrate > syncto.log &&\

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,6 +18,12 @@ By default, *Sycnto* persists internal cache in Redis.
 
     make serve
 
+If you already installed Syncto earlier and you want to recreate a
+full environment (because of errors when running ``make serve``), please run::
+
+    make maintainer-clean serve
+
+
 Authentication
 --------------
 


### PR DESCRIPTION
Reading http://syncto.readthedocs.org/en/latest/installation.html#run-locally it's not very clear what the instructions are. It mentions that you need to run `make serve` but not that you need to run `.venv/bin/pip install -Ue .` (maybe this is obvious to people who are used to working with `venv` and `pip`, but for me this was confusing).
