### PR TITLE
Mention git clone step

### DIFF
--- a/config/development.ini
+++ b/config/development.ini
@@ -8,6 +8,8 @@ cliquet.cache_backend = cliquet.cache.memory
 cliquet.storage_backend = cliquet.storage.memory
 cliquet.permission_backend = cliquet.permission.memory
 
+syncto.cache_hmac_secret = "70a73e5719a5f844cfb5dc02d8b370f718ced6fe9b93d81b8c42c5ee417b6bbb"
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,6 +16,8 @@ By default, *Sycnto* persists internal cache in Redis.
 
 ::
 
+    git clone https://github.com/mozilla-services/syncto
+    cd syncto
     make serve
 
 If you already installed Syncto earlier and you want to recreate a


### PR DESCRIPTION
(This is a PR against the `28-maintainer-clean` branch.)

With this addition, it's easy for people if they can just cut-and-paste this into their terminal. :)

However, even when I tried this, I got this error:

```
  Running setup.py install for cliquet
Successfully installed Jinja2-2.8 MarkupSafe-0.23 Pygments-2.0.2 Sphinx-1.3.1 WebTest-2.0.18 alabaster-0.7.6 babel-2.1.1 beautifulsoup4-4.4.0 cliquet-2.8.0.dev0 cov-core-1.15.0 coverage-4.0 docutils-0.12 funcsigs-0.4 mock-1.3.0 nose-1.3.7 nose-cov-1.6 nose-mocha-reporter-0.1 pbr-1.8.0 pytz-2015.6 snowballstemmer-1.2.0 sphinx-rtd-theme-0.1.9
touch .venv/.dev_env_installed.stamp
.venv/bin/cliquet --ini config/development.ini migrate
Traceback (most recent call last):
  File ".venv/bin/cliquet", line 9, in <module>
    load_entry_point('cliquet==2.8.0.dev0', 'console_scripts', 'cliquet')()
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/cliquet/scripts/cliquet.py", line 45, in main
    env = bootstrap(args.ini_file)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/pyramid/paster.py", line 131, in bootstrap
    app = get_app(config_uri, options=options)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/pyramid/paster.py", line 31, in get_app
    global_conf=options)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/Users/Michiel/soper/syncto/.venv/lib/python2.7/site-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/Users/Michiel/soper/syncto/syncto/__init__.py", line 31, in main
    "Please configure the `syncto.cache_hmac_secret` settings.")
ValueError: Please configure the `syncto.cache_hmac_secret` settings.
make: *** [serve] Error 1
```

Is there an easy solution for that or should I open a separate bug?
