### PR TITLE
Disable write operations by default (ref #26)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -120,21 +120,7 @@ Recommended settings
 
 Most default setting values in the application code base are suitable for production.
 
-However, **for safety reasons**, it might be appropriate to disable write operations
-to remote Sync collections:
-
-.. code-block :: ini
-
-    syncto.record_tabs_put_enabled = false
-    syncto.record_tabs_delete_enabled = false
-    syncto.record_passwords_put_enabled = false
-    syncto.record_passwords_delete_enabled = false
-    syncto.record_bookmarks_put_enabled = false
-    syncto.record_bookmarks_delete_enabled = false
-    syncto.record_history_put_enabled = false
-    syncto.record_history_delete_enabled = false
-
-Furthermore, the set of settings mentionned below might deserve some review or adjustments:
+However, the set of settings mentionned below might deserve some review or adjustments:
 
 .. code-block :: ini
 
@@ -150,6 +136,25 @@ Furthermore, the set of settings mentionned below might deserve some review or a
 
     For an exhaustive list of available settings and their default values,
     refer to `cliquet source code <https://github.com/mozilla-services/cliquet/blob/2.3.1/cliquet/__init__.py#L26-L78>`_.
+
+
+Enable write access
+-------------------
+
+By default, collections are read-only. In order to enable write operations
+on remote Sync collections, add some settings in the configuration with the
+collection name:
+
+.. code-block :: ini
+
+    syncto.record_tabs_put_enabled = true
+    syncto.record_tabs_delete_enabled = true
+    syncto.record_passwords_put_enabled = true
+    syncto.record_passwords_delete_enabled = true
+    syncto.record_bookmarks_put_enabled = true
+    syncto.record_bookmarks_delete_enabled = true
+    syncto.record_history_put_enabled = true
+    syncto.record_history_delete_enabled = true
 
 
 Monitoring

--- a/syncto/__init__.py
+++ b/syncto/__init__.py
@@ -19,11 +19,7 @@ CLIENT_STATE_HEADER = 'X-Client-State'
 
 DEFAULT_SETTINGS = {
     'syncto.cache_hmac_secret': None,
-    'syncto.cache_credentials_ttl_seconds': 300,
-    'syncto.record_meta_put_enabled': False,
-    'syncto.record_meta_delete_enabled': False,
-    'syncto.record_crypto_put_enabled': False,
-    'syncto.record_crypto_delete_enabled': False,
+    'syncto.cache_credentials_ttl_seconds': 300
 }
 
 

--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -147,6 +147,12 @@ class BaseViewTest(BaseWebTest, unittest.TestCase):
 
         self.addCleanup(p.stop)
 
+    def get_app_settings(self, extra=None):
+        settings = super(BaseViewTest, self).get_app_settings(extra)
+        settings['syncto.record_tabs_put_enabled'] = True
+        settings['syncto.record_tabs_delete_enabled'] = True
+        return settings
+
 
 class CollectionTest(FormattedErrorMixin, BaseViewTest):
 
@@ -379,30 +385,18 @@ class RecordTest(BaseViewTest):
 
 
 class WriteSafeguardTest(FormattedErrorMixin, BaseViewTest):
-    def get_app_settings(self, extra=None):
-        settings = super(WriteSafeguardTest, self).get_app_settings(extra)
-        settings['syncto.record_tabs_put_enabled'] = False
-        settings['syncto.record_tabs_delete_enabled'] = False
-        return settings
-
-    def test_record_put_is_disabled_on_meta_and_crypto(self):
+    def test_record_put_is_disabled_by_default(self):
         url = RECORD_URL.replace('tabs', 'meta')
         self.app.put_json(url, RECORD_EXAMPLE,
                           headers=self.headers, status=405)
 
-    def test_record_delete_is_disabled_on_meta_and_crypto(self):
+    def test_record_delete_is_disabled_by_default(self):
         url = RECORD_URL.replace('tabs', 'meta')
         self.app.delete(url, headers=self.headers, status=405)
 
-    def test_record_put_is_disabled(self):
-        self.app.put_json(RECORD_URL, RECORD_EXAMPLE,
-                          headers=self.headers, status=405)
-
-    def test_record_delete_is_disabled(self):
-        self.app.delete(RECORD_URL, headers=self.headers, status=405)
-
     def test_message_provides_details(self):
-        resp = self.app.put_json(RECORD_URL, RECORD_EXAMPLE,
+        url = RECORD_URL.replace('tabs', 'meta')
+        resp = self.app.put_json(url, RECORD_EXAMPLE,
                                  headers=self.headers, status=405)
         self.assertFormattedError(
             resp, 405, ERRORS.METHOD_NOT_ALLOWED, 'Method Not Allowed',

--- a/syncto/views/record.py
+++ b/syncto/views/record.py
@@ -30,7 +30,7 @@ def assert_endpoint_enabled(request, collection_name):
     settings = request.registry.settings
     method = request.method.lower()
     setting_key = 'syncto.record_%s_%s_enabled' % (collection_name, method)
-    enabled = settings.get(setting_key, True)
+    enabled = settings.get(setting_key, False)
     if not enabled:
         error_msg = 'Endpoint disabled for this collection in configuration.'
         response = errors.http_error(httpexceptions.HTTPMethodNotAllowed(),


### PR DESCRIPTION
This changes the implementation of PR #35 to
make collections read-only by default.

Write operations are enabled per collection,
as suggested by @michielbdejong 
