### PR TITLE
500 error when running Syncto locally with WiFi disabled.

### DIFF
--- a/syncto/views/errors.py
+++ b/syncto/views/errors.py
@@ -13,7 +13,7 @@ from syncto.headers import export_headers
 
 @view_config(context=HTTPError, permission=NO_PERMISSION_REQUIRED)
 def response_error(context, request):
-    """Catch server errors and trace them."""
+    """Catch response error from Sync and trace them."""
     message = '%s %s: %s' % (context.response.status_code,
                              context.response.reason,
                              context.response.text)
@@ -54,7 +54,7 @@ def response_error(context, request):
 
 @view_config(context=RequestException, permission=NO_PERMISSION_REQUIRED)
 def request_error(context, request):
-    """Catch requests errors when issuing a request."""
+    """Catch requests errors when issuing a request to Sync."""
     logger.error(context, exc_info=True)
 
     error_msg = ("Unable to reach the service. "

--- a/syncto/views/errors.py
+++ b/syncto/views/errors.py
@@ -1,7 +1,7 @@
 from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED, forget
 from pyramid.view import view_config
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException
 
 from cliquet import logger
 from cliquet.errors import http_error, ERRORS
@@ -12,7 +12,7 @@ from syncto.headers import export_headers
 
 
 @view_config(context=HTTPError, permission=NO_PERMISSION_REQUIRED)
-def error(context, request):
+def response_error(context, request):
     """Catch server errors and trace them."""
     message = '%s %s: %s' % (context.response.status_code,
                              context.response.reason,
@@ -42,9 +42,25 @@ def error(context, request):
                                   errno=ERRORS.INVALID_RESOURCE_ID,
                                   message=message)
         else:
-            response = service_unavailable(context, request)
+            response = service_unavailable(
+                httpexceptions.HTTPServiceUnavailable(),
+                request)
 
     request.response = response
     export_headers(context.response, request)
 
     return reapply_cors(request, response)
+
+
+@view_config(context=RequestException, permission=NO_PERMISSION_REQUIRED)
+def request_error(context, request):
+    """Catch requests errors when issuing a request."""
+    logger.error(context, exc_info=True)
+
+    error_msg = ("Unable to reach the service. "
+                 "Check your internet connection or firewall configuration.")
+    response = http_error(httpexceptions.HTTPServiceUnavailable(),
+                          errno=ERRORS.BACKEND,
+                          message=error_msg)
+
+    return service_unavailable(response, request)


### PR DESCRIPTION
Simple to reproduce, at least on my machine ;)
- Run syncto on localhost.
- See everything work fine.
- Disconnect from wifi.
- Next request to syncto will yield a 500 Internal Server Error.

Maybe something like '503 Service Unavailable' would be more appropriate (I guess we want 500 to never ever occur?).
