### PR TITLE
Added warning note about openssl and OSX.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,6 +20,11 @@ By default, *Sycnto* persists internal cache in Redis.
     cd syncto
     make serve
 
+:note:
+   OSX users are warned that supplementary steps are needed to ensure proper
+   installation of cryptographic dependencies is properly done; see
+   :ref:`dedicated note <osx-install-warning>`.
+
 If you already installed Syncto earlier and you want to recreate a
 full environment (because of errors when running ``make serve``), please run::
 
@@ -110,6 +115,17 @@ Assuming `brew <http://brew.sh/>`_ is installed:
 ::
 
     brew install libffi openssl pkg-config
+
+.. _osx-install-warning:
+
+.. warning::
+
+   Apple having dropped support for OpenSSL and moving to their own library
+   recently, you have to force its usage to properly install cryptography-related
+   dependencies::
+
+       $ env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" .venv/bin/pip install cryptography
+       $ make serve
 
 
 Running in production

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -124,7 +124,9 @@ Assuming `brew <http://brew.sh/>`_ is installed:
    recently, you have to force its usage to properly install cryptography-related
    dependencies::
 
-       $ env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" .venv/bin/pip install cryptography
+       $ env LDFLAGS="-L$(brew --prefix openssl)/lib" \
+             CFLAGS="-I$(brew --prefix openssl)/include" \
+                 .venv/bin/pip install cryptography
        $ make serve
 
 


### PR DESCRIPTION
Installing crypto dependencies on OSX the way it's currently documented triggers errors; this patch adds a warning about that and provide instructions to solve the issue.
