### PR TITLE
Log syncclient status code in statsd rather than logging the exception in Sentry.

### DIFF
--- a/syncto/tests/test_statsd.py
+++ b/syncto/tests/test_statsd.py
@@ -103,21 +103,30 @@ class StatsdHTTPErrorStatusCodeTest(StatsdTestMixin, unittest.TestCase):
     def test_response_error_counts_401_in_statsd(self):
         response = mock.MagicMock()
         response.status_code = 401
-        response_error(HTTPError(response=response), self.request)
+        try:
+            raise HTTPError(response=response)
+        except HTTPError as e:
+            response_error(e, self.request)
         self.mocked_client.incr.assert_called_with(
             "syncclient.status_code.401", count=1)
 
     def test_response_error_counts_403_in_statsd(self):
         response = mock.MagicMock()
         response.status_code = 403
-        response_error(HTTPError(response=response), self.request)
+        try:
+            raise HTTPError(response=response)
+        except HTTPError as e:
+            response_error(e, self.request)
         self.mocked_client.incr.assert_called_with(
             "syncclient.status_code.403", count=1)
 
     def test_response_error_counts_404_in_statsd(self):
         response = mock.MagicMock()
         response.status_code = 404
-        response_error(HTTPError(response=response), self.request)
+        try:
+            raise HTTPError(response=response)
+        except HTTPError as e:
+            response_error(e, self.request)
         self.mocked_client.incr.assert_called_with(
             "syncclient.status_code.404", count=1)
 

--- a/syncto/tests/test_statsd.py
+++ b/syncto/tests/test_statsd.py
@@ -3,15 +3,18 @@ import mock
 from cliquet import statsd
 from cliquet.cache.memory import Memory
 from cliquet.tests.support import DummyRequest
-
+from requests.exceptions import HTTPError
 
 from syncto import AUTHORIZATION_HEADER, CLIENT_STATE_HEADER
 from syncto.authentication import build_sync_client
 from syncto.tests.support import unittest, ENCRYPTED_CREDENTIALS
+from syncto.views import collection, record
+from syncto.views.errors import response_error
+
+COLLECTION_URL = "/buckets/syncto/collections/tabs/records"
 
 
-@unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
-class StatsdSyncClientTest(unittest.TestCase):
+class StatsdTestMixin(object):
 
     def setUp(self):
         self.client = statsd.Client('localhost', 1234, 'prefix')
@@ -26,10 +29,18 @@ class StatsdSyncClientTest(unittest.TestCase):
             'cache_credentials_ttl_seconds': 300})
         self.request.headers = {AUTHORIZATION_HEADER: 'Browserid 1234',
                                 CLIENT_STATE_HEADER: '12345'}
+        self.request.response.headers = {'Content-Type': 'application/json'}
 
         self.request.registry.cache = Memory()
         self.request.registry.cache.flush()
         self.request.registry.statsd = self.client
+
+
+@unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
+class StatsdSyncClientTest(StatsdTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(StatsdSyncClientTest, self).setUp()
 
         self.credentials = {
             "api_endpoint": "http://example.org/",
@@ -66,3 +77,123 @@ class StatsdSyncClientTest(unittest.TestCase):
                     'syncclient.syncclient.put_record')
                 self.mocked_client.timer.assert_any_call(
                     'syncclient.syncclient.delete_record')
+
+
+@unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
+class StatsdHTTPErrorStatusCodeTest(StatsdTestMixin, unittest.TestCase):
+
+    def test_response_error_counts_500_in_statsd_and_in_sentry(self):
+        response = mock.MagicMock()
+        response.status_code = 500
+        with mock.patch('syncto.views.errors.logger') as logger_mock:
+            logger_mock.error.return_value = None
+            error = HTTPError(response=response)
+            response_error(error, self.request)
+            self.mocked_client.incr.assert_called_with(
+                "syncclient.status_code.500", count=1)
+            logger_mock.error.assert_called_with(error, exc_info=True)
+
+    def test_response_error_counts_304_in_statsd(self):
+        response = mock.MagicMock()
+        response.status_code = 304
+        response_error(HTTPError(response=response), self.request)
+        self.mocked_client.incr.assert_called_with(
+            "syncclient.status_code.304", count=1)
+
+    def test_response_error_counts_401_in_statsd(self):
+        response = mock.MagicMock()
+        response.status_code = 401
+        response_error(HTTPError(response=response), self.request)
+        self.mocked_client.incr.assert_called_with(
+            "syncclient.status_code.401", count=1)
+
+    def test_response_error_counts_403_in_statsd(self):
+        response = mock.MagicMock()
+        response.status_code = 403
+        response_error(HTTPError(response=response), self.request)
+        self.mocked_client.incr.assert_called_with(
+            "syncclient.status_code.403", count=1)
+
+    def test_response_error_counts_404_in_statsd(self):
+        response = mock.MagicMock()
+        response.status_code = 404
+        response_error(HTTPError(response=response), self.request)
+        self.mocked_client.incr.assert_called_with(
+            "syncclient.status_code.404", count=1)
+
+    def test_response_error_counts_412_in_statsd(self):
+        response = mock.MagicMock()
+        response.status_code = 412
+        response_error(HTTPError(response=response), self.request)
+        self.mocked_client.incr.assert_called_with(
+            "syncclient.status_code.412", count=1)
+
+
+@unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
+class StatsdSuccessStatusCodeTest(StatsdTestMixin, unittest.TestCase):
+
+    def test_collection_get_counts_200_in_statsd(self):
+        with mock.patch(
+                'syncto.views.collection.build_sync_client') as build_mock:
+
+            build_mock.return_value._authenticate.return_value = None
+            build_mock.return_value.get_records.return_value = []
+
+            self.request.matchdict['collection_name'] = 'history'
+            collection.collection_get(self.request)
+
+            self.mocked_client.incr.assert_called_with(
+                "syncclient.status_code.200", count=1)
+
+    def test_record_get_counts_200_in_statsd(self):
+        with mock.patch(
+                'syncto.views.record.build_sync_client') as build_mock:
+
+            build_mock.return_value._authenticate.return_value = None
+            build_mock.return_value.get_records.return_value = {}
+
+            self.request.matchdict['collection_name'] = 'history'
+            self.request.matchdict['record_id'] = '1234'
+            record.record_get(self.request)
+
+            self.mocked_client.incr.assert_called_with(
+                "syncclient.status_code.200", count=1)
+
+    def test_record_put_counts_200_in_statsd(self):
+        with mock.patch(
+                'syncto.views.record.build_sync_client') as build_mock:
+
+            build_mock.return_value._authenticate.return_value = None
+            build_mock.return_value.get_records.return_value = {}
+
+            self.request.matchdict['collection_name'] = 'history'
+            self.request.matchdict['record_id'] = '1234'
+            self.request.validated['data'] = {}
+
+            self.request.method = 'PUT'
+            self.request.registry.settings['record_history_put_enabled'] = True
+
+            record.record_put(self.request)
+
+            self.mocked_client.incr.assert_called_with(
+                "syncclient.status_code.200", count=1)
+
+    def test_record_delete_counts_200_in_statsd(self):
+        with mock.patch(
+                'syncto.views.record.build_sync_client') as build_mock:
+
+            build_mock.return_value._authenticate.return_value = None
+            build_mock.return_value.get_records.return_value = {}
+
+            self.request.matchdict['collection_name'] = 'history'
+            self.request.matchdict['record_id'] = '1234'
+            self.request.validated['data'] = {}
+
+            self.request.method = 'DELETE'
+            settings = self.request.registry.settings
+            settings['record_history_delete_enabled'] = True
+
+            record.record_delete(self.request)
+
+            self.mocked_client.incr.assert_called_with(
+                "syncclient.status_code.204", count=1)

--- a/syncto/views/collection.py
+++ b/syncto/views/collection.py
@@ -61,6 +61,10 @@ def collection_get(request):
     records = sync_client.get_records(collection_name, full=True,
                                       headers=headers, **params)
 
+    statsd = request.registry.statsd
+    if statsd:
+        statsd.count("syncclient.status_code.200")
+
     for r in records:
         r['last_modified'] = int(r.pop('modified') * 1000)
 

--- a/syncto/views/errors.py
+++ b/syncto/views/errors.py
@@ -17,39 +17,45 @@ def response_error(context, request):
     message = '%s %s: %s' % (context.response.status_code,
                              context.response.reason,
                              context.response.text)
+
+    statsd = request.registry.statsd
+
+    if statsd:
+        statsd.count("syncclient.status_code.%s" %
+                     context.response.status_code)
+
     # For this specific code we do not want to log the error.
     if context.response.status_code == 304:
         response = httpexceptions.HTTPNotModified()
+    elif context.response.status_code == 400:
+        response = http_error(httpexceptions.HTTPBadRequest(),
+                              errno=ERRORS.INVALID_PARAMETERS,
+                              message=message)
+    elif context.response.status_code == 401:
+        response = http_error(httpexceptions.HTTPUnauthorized(),
+                              errno=ERRORS.INVALID_AUTH_TOKEN,
+                              message=message)
+        # Forget the current user credentials.
+        response.headers.extend(forget(request))
+    elif context.response.status_code == 403:
+        response = http_error(httpexceptions.HTTPForbidden(),
+                              errno=ERRORS.FORBIDDEN,
+                              message=message)
+    elif context.response.status_code == 404:
+        response = http_error(httpexceptions.HTTPNotFound(),
+                              errno=ERRORS.INVALID_RESOURCE_ID,
+                              message=message)
+    elif context.response.status_code == 412:
+        message = 'Resource was modified meanwhile'
+        response = http_error(httpexceptions.HTTPPreconditionFailed(),
+                              errno=ERRORS.MODIFIED_MEANWHILE,
+                              message=message)
     else:
         # For this code we also want to log the error.
         logger.error(context, exc_info=True)
-        if context.response.status_code == 400:
-            response = http_error(httpexceptions.HTTPBadRequest(),
-                                  errno=ERRORS.INVALID_PARAMETERS,
-                                  message=message)
-        elif context.response.status_code == 401:
-            response = http_error(httpexceptions.HTTPUnauthorized(),
-                                  errno=ERRORS.INVALID_AUTH_TOKEN,
-                                  message=message)
-            # Forget the current user credentials.
-            response.headers.extend(forget(request))
-        elif context.response.status_code == 403:
-            response = http_error(httpexceptions.HTTPForbidden(),
-                                  errno=ERRORS.FORBIDDEN,
-                                  message=message)
-        elif context.response.status_code == 404:
-            response = http_error(httpexceptions.HTTPNotFound(),
-                                  errno=ERRORS.INVALID_RESOURCE_ID,
-                                  message=message)
-        elif context.response.status_code == 412:
-            message = 'Resource was modified meanwhile'
-            response = http_error(httpexceptions.HTTPPreconditionFailed(),
-                                  errno=ERRORS.MODIFIED_MEANWHILE,
-                                  message=message)
-        else:
-            response = service_unavailable(
-                httpexceptions.HTTPServiceUnavailable(),
-                request)
+        response = service_unavailable(
+            httpexceptions.HTTPServiceUnavailable(),
+            request)
 
     request.response = response
     export_headers(context.response, request)

--- a/syncto/views/errors.py
+++ b/syncto/views/errors.py
@@ -24,6 +24,10 @@ def response_error(context, request):
         statsd.count("syncclient.status_code.%s" %
                      context.response.status_code)
 
+    if context.response.status_code in (400, 401, 403, 404):
+        # For this code we also want to log the info about the error.
+        logger.info(context, exc_info=True)
+
     # For this specific code we do not want to log the error.
     if context.response.status_code == 304:
         response = httpexceptions.HTTPNotModified()

--- a/syncto/views/record.py
+++ b/syncto/views/record.py
@@ -61,6 +61,10 @@ def record_get(request):
     # Configure headers
     export_headers(sync_client.raw_resp, request)
 
+    statsd = request.registry.statsd
+    if statsd:
+        statsd.count("syncclient.status_code.200")
+
     return {'data': record}
 
 
@@ -89,6 +93,10 @@ def record_put(request):
     # Configure headers
     export_headers(sync_client.raw_resp, request)
 
+    statsd = request.registry.statsd
+    if statsd:
+        statsd.count("syncclient.status_code.200")
+
     return {'data': record}
 
 
@@ -104,6 +112,10 @@ def record_delete(request):
     headers = import_headers(request)
     sync_client = build_sync_client(request)
     sync_client.delete_record(collection_name, sync_id, headers=headers)
+
+    statsd = request.registry.statsd
+    if statsd:
+        statsd.count("syncclient.status_code.204")
 
     request.response.status_code = 204
     del request.response.headers['Content-Type']


### PR DESCRIPTION
```
"GET   /v1/buckets/syncto/collections/meta/records" ? (? ms) 401 Client Error: Unauthorized for url: https://token.services.mozilla.com/1.0/sync/1.5?duration=300 lang=en-US,en;q=0.5; exception=Traceback (most recent call last):
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/tweens.py", line 21, in excview_tween
    response = handler(request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/router.py", line 163, in handle_request
    response = view_callable(context, request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/config/views.py", line 596, in __call__
    return view(context, request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/config/views.py", line 329, in attr_view
    return view(context, request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/config/views.py", line 305, in predicate_wrapper
    return view(context, request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/config/views.py", line 355, in rendered_view
    result = view(context, request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/pyramid/config/views.py", line 501, in _requestonly_view
    response = view(request)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/cornice/service.py", line 573, in wrapper
    response = view_(request)
  File "/home/ubuntu/syncto/syncto/views/collection.py", line 21, in collection_get
    sync_client = build_sync_client(request)
  File "/home/ubuntu/syncto/syncto/authentication.py", line 65, in build_sync_client
    credentials = tokenserver.get_hawk_credentials(duration=ttl)
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/syncclient/client.py", line 68, in get_hawk_credentials
    raw_resp.raise_for_status()
  File "/home/ubuntu/venvs/syncto/local/lib/python2.7/site-packages/requests/models.py", line 837, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
HTTPError: 401 Client Error: Unauthorized for url: https://token.services.mozilla.com/1.0/sync/1.5?duration=300; uid=None; errno=None; agent=Mozilla/5.0 (Mobile; rv:43.0) Gecko/20100101 Firefox/43.0; authn_type=None
```
