### PR TITLE
Total-Records should give the total number of records.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ Syncto
     :target: https://coveralls.io/r/mozilla-services/syncto
 
 Syncto is a server allowing you to store and retrieve Firefox Sync
-user data attached to your Firefox account using the Kinto API in
-order to be able to use Kinto.js for that task.
+user data attached to your Firefox account using a subset of the Kinto
+API in order to be able to use Kinto.js for that task.
 
 * `Online documentation <http://syncto.readthedocs.org/en/latest/>`_
 * `Issue tracker <https://github.com/mozilla-services/syncto/issues>`_

--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -270,6 +270,12 @@ class CollectionTest(FormattedErrorMixin, BaseViewTest):
         self.assertEquals(resp.headers['Next-Page'], next_page)
         self.assertEquals(resp.headers['Quota-Remaining'], '125')
 
+    def test_collection_does_not_return_Total_Records_when_paginating(self):
+        resp = self.app.get(COLLECTION_URL+'?_limit=2',
+                            headers=self.headers, status=200)
+        self.assertNotIn('Total-Records', resp.headers)
+        self.assertIn('Next-Page', resp.headers)
+
     def test_collection_return_a_307_in_case_of_not_modified_resource(self):
         response = mock.MagicMock()
         response.status_code = 304

--- a/syncto/views/collection.py
+++ b/syncto/views/collection.py
@@ -67,5 +67,8 @@ def collection_get(request):
     # Configure headers
     export_headers(sync_client.raw_resp, request)
 
+    if '_limit' in request.GET and 'Total-Records' in request.response.headers:
+        del request.response.headers['Total-Records']
+
     if records:
         return {'data': records}


### PR DESCRIPTION
Today `Total-Record` only contains the number of records in the current request.
Kinto protocol defines it to be the total number of records for the collection.

We should use the `syncclient.info_collection()` methods in order to return the right number of records. We may want to cache this value when used with pagination.
