### PR TITLE
Prefix for public setting in hello view

### DIFF
--- a/syncto/__init__.py
+++ b/syncto/__init__.py
@@ -31,6 +31,9 @@ def main(global_config, **settings):
     cliquet.initialize(config, __version__, 'syncto',
                        default_settings=DEFAULT_SETTINGS)
 
+    # Retro-compatibility with first Kinto clients.
+    config.registry.public_settings.add('cliquet.batch_max_requests')
+
     settings = config.get_settings()
 
     if settings['cache_hmac_secret'] is None:

--- a/syncto/tests/test_functional.py
+++ b/syncto/tests/test_functional.py
@@ -35,6 +35,13 @@ class SettingsMissingTest(unittest.TestCase):
 
 class ErrorsTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
 
+    def test_public_settings_are_shown_in_view_prefixed_with_cliquet(self):
+        response = self.app.get('/')
+        settings = response.json['settings']
+        expected = {'batch_max_requests': 25,
+                    'cliquet.batch_max_requests': 25}
+        self.assertEqual(expected, settings)
+
     def test_authorization_header_is_required_for_collection(self):
         resp = self.app.get(COLLECTION_URL, headers=self.headers, status=401)
 


### PR DESCRIPTION
With cliquet 2.8.0 the public setting `max_batch_requests` is exposed with the project name.

kinto.js now expects `cliquet.max_batch_requests`. We should probably update it to `kinto.max_batch_requests`. But since there seems to be a code-freeze around kinto.js, I believe we should manage the retro-compatibilty here.

By explicitly adding public settings prefixed with `cliquet.` and `kinto.`. Like it is done here:
https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L48
