### PR TITLE
[WiP] Allow any bucket_id (not just 'syncto')

### DIFF
--- a/syncto/views/collection.py
+++ b/syncto/views/collection.py
@@ -9,7 +9,7 @@ from syncto.headers import import_headers, export_headers
 
 collection = Service(name='collection',
                      description='Firefox Sync Collection service',
-                     path=('/buckets/syncto/collections'
+                     path=('/buckets/{bucket_id}/collections'
                            '/{collection_name}/records'),
                      cors_headers=('Next-Page', 'Total-Records',
                                    'Last-Modified', 'ETag', 'Quota-Remaining'))

--- a/syncto/views/record.py
+++ b/syncto/views/record.py
@@ -41,7 +41,7 @@ def assert_endpoint_enabled(request, collection_name):
 
 record = Service(name='record',
                  description='Firefox Sync Collection Record service',
-                 path=('/buckets/syncto/collections/'
+                 path=('/buckets/{bucket_id}/collections/'
                        '{collection_name}/records/{record_id}'),
                  cors_headers=('Last-Modified', 'ETag'))
 


### PR DESCRIPTION
Ref #9.

This is what I'm using to test https://bugzilla.mozilla.org/show_bug.cgi?id=1217760.

To do:
[ ] If `bucket_id !== 'syncto'`, use `bucket_id` instead of the `X-Client-State` request header to determine `xClientState`.
[ ] Add tests.
